### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can download a `.aar` from GitHub's [releases page](https://github.com/DevLi
 Or use Gradle:
 
 ```groovy
-compile 'devlight.io:arcprogressstackview:1.0.4'
+implementation 'devlight.io:arcprogressstackview:1.0.4'
 ```
 
 Or Maven:  


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.